### PR TITLE
Backport the SM spinjump behavior setting toggle

### DIFF
--- a/source/metroid3/samus/rom_export.py
+++ b/source/metroid3/samus/rom_export.py
@@ -89,6 +89,13 @@ def rom_export(player_sprite, old_rom, verbose=False):
 	if verbose: print("done" if success_code else "FAIL")
 
 	#now we're going to get set up for screw attack without space jump
+
+	#Total: "firstly" off, we write a spinjump config value
+
+	if verbose: print("Writing spinjump config value", end="")
+	success_code = write_spinjump_config(rom)
+	if verbose: print("done" if success_code else "FAIL")
+
 	#first off, we need a new control code that checks for space jump, so that we can gate the animation appropriately
 
 	if verbose: print("Creating new control code...", end="")
@@ -832,18 +839,37 @@ def disable_upper_bypass(samus,rom):
 	success_code = rom._apply_single_fix_to_snes_address(0x90864E, OLD_SUBROUTINES, NEW_SUBROUTINES, "2"*28)
 	return success_code
 
+def write_spinjump_config(rom):
+	# Use the new screw attack animations if enabled
+	rom.write_to_snes_address(0xB4F500, 0x0001, 2)
+	return True
+
 def create_new_control_code(samus,rom):
 	#new control code: place at $908688-$9086A2 (0x1B bytes)
-	SUBROUTINE_LOCATION = 0x908688
+	#Total: Relocated this to freespace at the end of bank 90 to fit and not overwrite things
+	SUBROUTINE_LOCATION = 0x90F640
+
 	'''
 	;I wrot this coed mysef
+	;Total: Adjusted to configure spinjump behavior
+	;-Total-
+	AF 00 F5 B4 ;LDA config_screwattack
+	F0 11       ;BEQ config_disabled    ; If config_screwattack is 0, use the vanilla screw attack code
+	;---
 	AD A2 09   ;LDA $09A2       ;get item equipped info
 	89 00 02   ;BIT #$0200      ;check for space jump equipped
-	D0 09      ;BNE space_jump  ;if space jump, branch to space jump stuff
+	D0 13      ;BNE space_jump  ;if space jump, branch to space jump stuff ;Total: relative adjusted
 	AD 96 0A   ;LDA $0A96       ;get the pose number
 	18         ;CLC             ;prepare to do math
 	69 1B 00   ;ADC #$001B      ;skip past the old screw attack to the new stuff
-	80 04      ;BRA get_out     ;then GET OUT after doing some important things after branching
+	80 0E      ;BRA get_out     ;then GET OUT after doing some important things after branching ;Total: relative adjusted
+	;-Total-
+	;:config_disabled
+	AD A2 09   ;LDA $09A2       ; This code is here just to make sure both implementations 
+	89 00 02   ;BIT #$0200      ; uses the same amount of clock cycles for pose selection
+	D0 02      ;BNE space_jump
+	EA EB      ;NOP : XBA
+	;---
 	;:space_jump
 	AD 96 0A   ;LDA $0A96       ;get the pose number
 	1A         ;INC A           ;just go to the next pose
@@ -853,13 +879,19 @@ def create_new_control_code(samus,rom):
 	38         ;SEC             ;flag the carry bit because reasons
 	60         ;RTS             ;now GET OUT
 	'''
-	NEW_SUBROUTINE = [  0xAD, 0xA2, 0x09,
+	NEW_SUBROUTINE = [  0xAF, 0x00, 0xF5, 0xB4,
+						0xF0, 0x11,
+						0xAD, 0xA2, 0x09,
 						0x89, 0x00, 0x02,
-						0xD0, 0x09,
+						0xD0, 0x13,
 						0xAD, 0x96, 0x0A,
 						0x18,
 						0x69, 0x1B, 0x00,
-						0x80, 0x04,
+						0x80, 0x0E,
+						0xAD, 0xA2, 0x09,
+						0x89, 0x00, 0x02,
+						0xD0, 0x02,
+						0xEA, 0xEB,
 						0xAD, 0x96, 0x0A,
 						0x1A,
 						0x8D, 0x96, 0x0A,
@@ -867,7 +899,7 @@ def create_new_control_code(samus,rom):
 						0x38,
 						0x60]
 
-	rom.bulk_write_to_snes_address(SUBROUTINE_LOCATION, NEW_SUBROUTINE, 0x1B)
+	rom.bulk_write_to_snes_address(SUBROUTINE_LOCATION, NEW_SUBROUTINE, 0x2B)
 
 	#need to link up this subroutine to control code $F5
 	success_code = rom._apply_single_fix_to_snes_address(0x90832E, 0x8344, SUBROUTINE_LOCATION % 0x10000, 2)
@@ -974,6 +1006,7 @@ def implement_spin_attack(samus,rom):
 
 	'''
 	By and large this new subroutine borrows heavily from control code $FB, which has to do similar checks
+	;Total: Adjusted to configure spinjump behavior
 	AD A2 09    LDA $09A2         ; get equipped items
 	89 20 00    BIT #$0020        ; check for gravity suit
 	D0 20       BNE equip_check   ; if gravity suit, underwater status is not important
@@ -986,13 +1019,11 @@ def implement_spin_attack(samus,rom):
 	89 04 00    BIT #$0004        ; If liquid physics are disabled, underwater status is not important
 	D0 0B       BNE equip_check
 	80 1D       BRA just_one_plz  ; ok, you're probably underwater at this point
-
-	:;acid_check
+	;:acid_check
 	AD 62 19    LDA $1962
 	30 04       BMI equip_check   ; If [lava/acid Y position] < 0, then there is no acid, so underwater status is not important
 	C5 14       CMP $14           ;
 	30 14       BMI just_one_plz  ; If [lava/acid Y position] < Samus' top boundary position, then you are underwater
-
 	;:equip_check
 	AD A2 09        ;LDA $09A2        ;get equipped items
 	89 08 00        ;BIT #$0008       ;check for screw attack equipped
@@ -1008,9 +1039,19 @@ def implement_spin_attack(samus,rom):
 	8D 9A 0A        ;STA $0A9A
 	6B              ;RTL              ;GET OUT
 	;:spin_attack
+	;-Total-
+	AF 00 F5 B4     ;LDA config_screwattack
+	F0 07           ;BEQ +
+	;---
 	A9 1C 00        ;LDA #001C        ;skip over to our new spin attack section
 	8D 9A 0A        ;STA $0A9A
 	6B              ;RTL              ;GET OUT
+	;-Total-
+	;+
+	A9 02 00        ;LDA #$0002
+	8D 9A 0A        ;STA $0A9A
+	6B 	            ;RTL
+	;---
 	'''
 	NEW_CODE = [0xAD, 0xA2, 0x09,
 				0x89, 0x20, 0x00,
@@ -1039,12 +1080,17 @@ def implement_spin_attack(samus,rom):
 				0xA9, 0x01, 0x00,
 				0x8D, 0x9A, 0x0A,
 				0x6B,
+				0xAF, 0x00, 0xF5, 0xB4,
+				0xF0, 0x07,
 				0xA9, 0x1C, 0x00,
+				0x8D, 0x9A, 0x0A,
+				0x6B,
+				0xA9, 0x02, 0x00,
 				0x8D, 0x9A, 0x0A,
 				0x6B]
 
 	#put the new code in the ROM
-	rom.bulk_write_to_snes_address(NEW_SUBROUTINE_LOCATION,NEW_CODE,74)
+	rom.bulk_write_to_snes_address(NEW_SUBROUTINE_LOCATION,NEW_CODE,87)
 
 	#loop in the new code
 	#previously: $91:F634 A9 01 00     LDA #$0001


### PR DESCRIPTION
The v11 Combo rando will allow for toggling the separate spinjump behavior. To keep the execution timing neutral between each setting the assembler code was adjusted. This commit backports the changed implementation so that the SpriteSomething application also produces race legal rom files.